### PR TITLE
Ajout de --single-transaction pour mysqldump

### DIFF
--- a/templates/sauv-db.sh.j2
+++ b/templates/sauv-db.sh.j2
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker exec aquarium-db bash -c "exec mysqldump --databases aquarium --default-character-set=utf8mb4 -uroot -p'{{ aquarium_bd_mdp }}'" | gzip > $HOME/aquarium-$(date +%F-%Hh%Mm).sql.gz
+docker exec aquarium-db bash -c "exec mysqldump --single-transaction --databases aquarium --default-character-set=utf8mb4 -uroot -p'{{ aquarium_bd_mdp }}'" | gzip > $HOME/aquarium-$(date +%F-%Hh%Mm).sql.gz


### PR DESCRIPTION
Ajout de l'option --single-transaction afin d'éviter un lock et afin d'avoir un dump cohérent.

The --single-transaction flag will start a transaction before running. Rather than lock the entire database, this will let mysqldump read the database in the current state at the time of the transaction, making for a consistent data dump.